### PR TITLE
Update libsshscan.py

### DIFF
--- a/libsshscan.py
+++ b/libsshscan.py
@@ -62,7 +62,7 @@ if args.target:
 
 
 for ip in ips:
-  results.append([ip, args.port, bannergrab(ip, args.port)])
+  results.append([ip, int(args.port), bannergrab(ip, int(args.port))])
 
 for result in results:
   if result[2]:


### PR DESCRIPTION
Before PR:

```bash
➜  Desktop python libssh-scanner.py -t XX.YY.WW.ZZ -p 22

Status: Searching for Vulnerable Hosts...

Traceback (most recent call last):
  File "libssh-scanner.py", line 65, in <module>
    results.append([ip, args.port, bannergrab(ip, args.port)])
  File "libssh-scanner.py", line 30, in bannergrab
    s.connect((ip,port))
  File "/usr/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
TypeError: an integer is required
```

With this fix:

```bash
➜  Desktop python libssh-scanner.py -t XX.YY.WW.ZZ  -p 22

Status: Searching for Vulnerable Hosts...

[*] XX.YY.WW.ZZ :22 is not vulnerable to authentication bypass (SSH-2.0-SSHD)

Scanner Completed Successfully
``` 
