### PR TITLE
Added CIDR range parsing using netaddr module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ libssh Scanner - Find vulnerable libssh services by Leap Security (@LeapSecurity
 
 positional arguments:
   target                An ip address or new line delimited file containing
-                        IPs to search for the vulnerability.
+                        IPs to search for the vulnerability. Also accepts
+                        a CIDR range.
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/libsshscan.py
+++ b/libsshscan.py
@@ -3,6 +3,7 @@
 
 
 import socket, argparse, sys, os, paramiko
+from netaddr import IPNetwork
 
 class colors(object):
     blue = "\033[1;34m"
@@ -57,7 +58,7 @@ def aggressive(ip, port): #bypass auth to verify vulnerable host
     pass
 
 parser = argparse.ArgumentParser(description='libssh Scanner - Find vulnerable libssh services by Leap Security (@LeapSecurity)', version="1.0.2")
-parser.add_argument('target', help="An ip address or new line delimited file containing IPs to banner grab for the vulnerability.")
+parser.add_argument('target', help="An ip address or new line delimited file containing IPs to banner grab for the vulnerability. Also accepts a CIDR range.")
 parser.add_argument('-p', '--port', default=22, help="Set port of SSH service")
 parser.add_argument("-a", "--aggressive", action="store_true", help="Identify vulnerable hosts by bypassing authentication")
 
@@ -75,6 +76,8 @@ if os.path.isfile(args.target): #if file add hosts
   with open (args.target) as f:
       for line in f.readlines():
           ips.append(line.strip())
+elif '/' in args.target: #if CIDR range, get hosts
+  ips = map(str, IPNetwork(args.target).iter_hosts())
 else: #if not scan the provided IP
   ips.append(args.target.strip())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 paramiko==2.4.2
+netaddr==0.7.19


### PR DESCRIPTION
Example:

```
C:\libssh-scanner>python libsshscan.py 192.168.1.0/28

libssh scanner 1.0.2

Searching for Vulnerable Hosts...

192.168.1.1:22 has timed out.
192.168.1.2:22 is not vulnerable to authentication bypass (SSH-2.0-OpenSSH_5.6)
192.168.1.3:22 is not vulnerable to authentication bypass (SSH-2.0-OpenSSH_5.2)
192.168.1.4:22 has timed out.
192.168.1.5:22 is not vulnerable to authentication bypass (SSH-2.0-OpenSSH_5.6)
192.168.1.6:22 has timed out.
192.168.1.7:22 has timed out.
192.168.1.8:22 has timed out.
192.168.1.9:22 has timed out.
192.168.1.10:22 has timed out.
192.168.1.11:22 has timed out.
192.168.1.12:22 has timed out.
192.168.1.13:22 has timed out.
192.168.1.14:22 has timed out.

Scanner Completed Successfully
```